### PR TITLE
Static ip addressing and ws+rest port (8050) expose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,37 @@
 version: "3"
 services:
   emr-service:
-    image: omrsregrepo/bahmni_092_emr:02122020
+    image: omrsregrepo/bahmni_092_emr:08122020
     restart: unless-stopped
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: [/usr/sbin/init, /bin/bash, "--privileged"]
     ports:
-      - "443:443"
-      - "80:80"
+      - "443:443" #https
+      - "80:80" #http
       - "8000:8000"
+      - "8050:8050" #openmrs ws and rest api live here
+    networks:
+            hmis_network:
+                ipv4_address: 172.27.0.3
+                
   erp-service:
-    image: omrsregrepo/bahmni_092_erp:02122020
+    image: omrsregrepo/bahmni_092_erp:08122020
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: [/usr/sbin/init, /bin/bash, "--privileged"]
     ports:
-      - "8069:8069"
+      - "8069:8069" #odoo lives here
+    networks:
+            hmis_network:
+                ipv4_address: 172.27.0.2
     restart: unless-stopped
+    
+networks:
+    hmis_network:
+        ipam:
+            driver: default
+            config:
+                - subnet: 172.27.0.0/16


### PR DESCRIPTION
Add docker network for static ips required by the bahmni-erp-connect
Expose port 8050 on emr container ... this is an openmrs port that that bahmni-erp-connect uses to pull feeds