### PR TITLE
Change ownership of volumes from root to openmrs

### DIFF
--- a/scripts/services.sh
+++ b/scripts/services.sh
@@ -178,6 +178,10 @@ cd /home/openmrs/bahmni_docker/scripts
  sudo chown openmrs:openmrs /etc/systemd/system/gitpull_outgoingmessage.service
  sudo chown openmrs:openmrs /etc/systemd/system/gitpull_dhisconnector.service
  
+ #Change ownership of persistent volumes from root to openmrs so that all services owned by openmrs run properly
+ sudo chown -R openmrs:openmrs /development_emr
+ sudo chown -R openmrs:openmrs /development_erp
+ 
  #Loading system daemon and enabling services
  
  sudo systemctl daemon-reload


### PR DESCRIPTION
Change ownership of persistent volumes from root to openmrs so that all services owned by openmrs run properly